### PR TITLE
update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Compiled class file
 *.class
+*.java
 
 # Log file
 *.log
@@ -24,8 +25,9 @@ hs_err_pid*
 
 # gradle
 .gradle
-gradlew.bat
-gradlew
 
 # idea
-.idea
+*.idea
+
+# misc
+**


### PR DESCRIPTION
fix gradle wrapper files being ignored (those are actually needed, to not have to install gradle manually)